### PR TITLE
Push to GCS nessie-maven repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.3
+      with:
+        service_account_key: ${{ secrets.NESSIE_MAVEN_GOOGLE_CREDENTIALS }}
+        export_default_credentials: true
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
@@ -34,7 +38,29 @@ jobs:
         export VERSION=`cat version.sbt|awk '{print $5}'|sed 's/"//g'`
         # maven doesn't like pushing from local repository so we copy before pushing
         cp /home/runner/.m2/repository/io/delta/delta-core_2.12/$VERSION/delta-core_2.12-$VERSION.* .
-        mvn -B deploy:deploy-file -DpomFile=delta-core_2.12-$VERSION.pom -DrepositoryId=github -Dfile=delta-core_2.12-$VERSION.jar -Durl=https://maven.pkg.github.com/projectnessie/delta
-      env:
-        GITHUB_TOKEN: ${{ github.token }} 
+        # create a maven settings file tailored to deploy to GCS
+        cat > settings.xml << 'EOT'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+         <servers>
+           <server>
+              <id>nessie-maven</id>
+              <configuration>
+                <httpConfiguration>
+                  <all>
+                    <headers>
+                      <property>
+                        <name>Authorization</name>
+                        <value>Bearer ${env.GOOGLE_OAUTH_TOKEN}</value>
+                      </property>
+                    </headers>
+                  </all>
+                </httpConfiguration>
+              </configuration>
+            </server>
+          </servers>
+        </settings>
+        EOT
+        GOOGLE_OAUTH_TOKEN=$(gcloud auth print-access-token) mvn -B -s settings.xml deploy:deploy-file -DpomFile=delta-core_2.12-$VERSION.pom -DrepositoryId=nessie-maven -Dfile=delta-core_2.12-$VERSION.jar -Durl=https://storage.googleapis.com/nessie-maven/
 


### PR DESCRIPTION
Switch publishing from github repository to `nessie-maven` Google Cloud
Storage bucket so that artifacts can be accessed publicly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/delta/10)
<!-- Reviewable:end -->
